### PR TITLE
Add gradle-wrapper.jar to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
## Summary
- ignore `gradle-wrapper.jar` so the wrapper jar can be downloaded automatically

## Testing
- `git rm gradle/wrapper/gradle-wrapper.jar` *(fails: pathspec not found)*
- `./gradlew --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d89ebf0832fbe4a986e561e5fdd